### PR TITLE
* Added a configuration option so that Vite Projects kept outside of …

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,14 @@ As mentioned above, a ViteConfig object must be passed to the `NewVueGlue()` rou
 | **Environment** | What mode you want vite to run in. | development |
 | **FS** | A fs.Embed or fs.DirFS | none; required. |
 | **JSProjectPath** | Path to your Javascript files | frontend |
+| **JSInExternalDir** | Javascript files are kept in a folder outside of the go project | false |  
 | **AssetPath** | Location of the built distribution directory | *Production:* dist|
 | **Platform** | Any platform supported by Vite. vue and react are known to work; other platforms *may* work if you adjust the other configurations correctly. | Based upon your package.json settings. |
 | **EntryPoint** | Entry point script for your Javascript | Best guess based on package.json |
 | **ViteVersion** | Vite major version ("2" or "3") | Best guess based on your package.json file in your project. If you want to make sure, specify the version you want. |
 | **DevServerPort** | Port the dev server will listen on; typically 3000 in version 2, 5173 in version 3 | Best guess based on version | 
 | **DevServerDomain** | Domain serving assets. | localhost |
-| **HTTPS** | Whether the dev server serves HTTPS | false | 
+| **HTTPS** | Whether the dev server serves HTTPS | false |  
 
 ## Caveats
 

--- a/utils.go
+++ b/utils.go
@@ -1,11 +1,12 @@
 package vueglue
 
 import (
-	"embed"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"regexp"
 )
 
@@ -35,12 +36,18 @@ type JSAppParams struct {
 }
 
 func (vc *ViteConfig) parsePackageJSON() (*PackageJSON, error) {
+	var buf []byte
+	var err error
+	path := filepath.Join(vc.JSProjectPath, "package.json")
 	// If not set, try and find package.json
-	path := ""
-	if _, ok := vc.FS.(embed.FS); ok {
-		path = vc.JSProjectPath + "/"
+	if vc.JSInExternalDir {
+		buf, err = os.ReadFile(path)
+	} else {
+		// The old code had a conditional for an embedded file system,
+		// but, if not using embed, left the path blank, taking control
+		// away from the user of the library.
+		buf, err = fs.ReadFile(vc.FS, path)
 	}
-	buf, err := fs.ReadFile(vc.FS, path+"package.json")
 	if err != nil {
 		return nil, err
 	}

--- a/vueglue.go
+++ b/vueglue.go
@@ -33,6 +33,11 @@ type ViteConfig struct {
 	// root of your project. Default: frontend
 	JSProjectPath string
 
+	// JSInExternalDir denotes that you keep your JS project source
+	// in a folder located external to your go project source.
+	// Default: false
+	JSInExternalDir bool
+
 	//AssetsPath relative to the JSProjectPath. Empty for dev, dist for prod
 	AssetsPath string
 


### PR DESCRIPTION
…the main go project can be used.

* Updated the README.md
* I removed the embed check in the parsePackageJSON function, mostly as it's only used to initialize the path. But, but adding the check, it removes control away from a user of the library as they hit a code conditional that forces ignoring deliberate setting of the JSProjectPath parameter. vc.FS is then used regardless of it being embedded or not.